### PR TITLE
Add public TryGetXliffVersion method to XLIFF serializers

### DIFF
--- a/Blackbird.Filters.Tests/Xliff1/Xliff12ValidTestSuiteTests.cs
+++ b/Blackbird.Filters.Tests/Xliff1/Xliff12ValidTestSuiteTests.cs
@@ -67,6 +67,24 @@ public class Xliff12ValidTestSuiteTests : TestBase
         Assert.That(units[0].Notes[0].Text, Is.EqualTo("Simple greeting"));
     }
 
+    [TestCase]
+    public void Basic_GetVersion()
+    {
+        // Arrange & Act
+        var filePath = $"Xliff1/Files/basic.xliff";
+        var fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+        // Act
+        var result = Xliff1Serializer.TryGetXliffVersion(fileContent, out var version);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(version, Is.EqualTo("1.2"));
+        });
+    }
+
     [Test]
     public void Segmented()
     {

--- a/Blackbird.Filters.Tests/Xliff1/Xliff12ValidTestSuiteTests.cs
+++ b/Blackbird.Filters.Tests/Xliff1/Xliff12ValidTestSuiteTests.cs
@@ -68,6 +68,31 @@ public class Xliff12ValidTestSuiteTests : TestBase
     }
 
     [TestCase]
+    public void Basic_IsXliff1()
+    {
+        // Arrange & Act
+        var filePath = $"Xliff1/Files/basic.xliff";
+        var fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+        // Act
+        var result = Xliff1Serializer.IsXliff1(fileContent);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [TestCase("<html version=\"4.01\"></html>")]
+    [TestCase("<xliff version=\"2.1\"></xliff>")]
+    public void Basic_IsXliff1_ForInvalidContent(string fileContent)
+    {
+        // Act
+        var result = Xliff1Serializer.IsXliff1(fileContent);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [TestCase]
     public void Basic_GetVersion()
     {
         // Arrange & Act

--- a/Blackbird.Filters.Tests/Xliff2/BaseXliff2SerializationTests.cs
+++ b/Blackbird.Filters.Tests/Xliff2/BaseXliff2SerializationTests.cs
@@ -42,6 +42,25 @@ public class BaseXliff2SerializationTests : TestBase
         Assert.That(content.GetUnits().FirstOrDefault()!.Notes.Count, Is.EqualTo(1));
     }
 
+
+    [TestCase]
+    public void Basic_GetVersion()
+    {
+        // Arrange & Act
+        var filePath = $"Xliff2/Files/basic.xliff";
+        var fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+        // Act
+        var result = Xliff2Serializer.TryGetXliffVersion(fileContent, out var version);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(version, Is.EqualTo("2.2"));
+        });
+    }
+
     [Test]
     public void Complex()
     {

--- a/Blackbird.Filters.Tests/Xliff2/BaseXliff2SerializationTests.cs
+++ b/Blackbird.Filters.Tests/Xliff2/BaseXliff2SerializationTests.cs
@@ -42,6 +42,30 @@ public class BaseXliff2SerializationTests : TestBase
         Assert.That(content.GetUnits().FirstOrDefault()!.Notes.Count, Is.EqualTo(1));
     }
 
+    [TestCase]
+    public void Basic_IsXliff2()
+    {
+        // Arrange & Act
+        var filePath = $"Xliff2/Files/basic.xliff";
+        var fileContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+        // Act
+        var result = Xliff2Serializer.IsXliff2(fileContent);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [TestCase("<html version=\"4.01\"></html>")]
+    [TestCase("<xliff version=\"1.2\"></xliff>")]
+    public void Basic_IsXliff2_ForInvalidContent(string fileContent)
+    {
+        // Act
+        var result = Xliff2Serializer.IsXliff2(fileContent);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
 
     [TestCase]
     public void Basic_GetVersion()

--- a/Blackbird.Filters/Blackbird.Filters.csproj
+++ b/Blackbird.Filters/Blackbird.Filters.csproj
@@ -11,7 +11,7 @@
 	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	  <PackageTags>Blackbird</PackageTags>
 	  <Copyright>Copyright © 2021-2025 Blackbird.io</Copyright>
-	  <Version>1.1.19</Version>
+	  <Version>1.1.20</Version>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/Blackbird.Filters/Xliff/Xliff1/Xliff1Serializer.cs
+++ b/Blackbird.Filters/Xliff/Xliff1/Xliff1Serializer.cs
@@ -73,31 +73,12 @@ public static class Xliff1Serializer
     
     public static bool IsXliff1(string content)
     {
-        try
+        if (TryGetXliffVersion(content, out var version))
         {
-            var xliffNode = Xliff1XmlExtensions.GetRootNode(content);
-            if (xliffNode == null)
-            {
-                return false;
-            }
-
-            if (xliffNode.Name.Namespace != XliffNs || xliffNode.Name.LocalName != "xliff")
-            {
-                return false;
-            }
-
-            var version = xliffNode.Get("version");
-            if (string.IsNullOrEmpty(version))
-            {
-                return false;
-            }
-
             return version.StartsWith("1.");
         }
-        catch (Exception)
-        {
-            return false;
-        }
+
+        return false;
     }
 
     public static bool TryGetXliffVersion(string content, out string version)
@@ -107,6 +88,9 @@ public static class Xliff1Serializer
         {
             var xliffNode = Xliff1XmlExtensions.GetRootNode(content);
             if (xliffNode == null)
+                return false;
+
+            if (xliffNode.Name.LocalName != "xliff")
                 return false;
 
             var v = xliffNode.Get("version");

--- a/Blackbird.Filters/Xliff/Xliff1/Xliff1Serializer.cs
+++ b/Blackbird.Filters/Xliff/Xliff1/Xliff1Serializer.cs
@@ -100,6 +100,29 @@ public static class Xliff1Serializer
         }
     }
 
+    public static bool TryGetXliffVersion(string content, out string version)
+    {
+        version = string.Empty;
+        try
+        {
+            var xliffNode = Xliff1XmlExtensions.GetRootNode(content);
+            if (xliffNode == null)
+                return false;
+
+            var v = xliffNode.Get("version");
+            if (string.IsNullOrEmpty(v))
+                return false;
+
+            version = v;
+            return true;
+        }
+        catch (Exception)
+        {
+            version = string.Empty;
+            return false;
+        }
+    }
+
     private static XElement? CloneWithNamespace(XObject? xobj)
     {
         if (xobj == null)

--- a/Blackbird.Filters/Xliff/Xliff2/Xliff2Serializer.cs
+++ b/Blackbird.Filters/Xliff/Xliff2/Xliff2Serializer.cs
@@ -1042,4 +1042,27 @@ public static class Xliff2Serializer
             return false;
         }
     }
+
+    public static bool TryGetXliffVersion(string content, out string version)
+    {
+        version = string.Empty;
+        try
+        {
+            var xliffNode = GetRootNode(content);
+            if (xliffNode == null)
+                return false;
+
+            var v = xliffNode.Get("version");
+            if (string.IsNullOrEmpty(v))
+                return false;
+
+            version = v;
+            return true;
+        }
+        catch (Exception)
+        {
+            version = string.Empty;
+            return false;
+        }
+    }
 }

--- a/Blackbird.Filters/Xliff/Xliff2/Xliff2Serializer.cs
+++ b/Blackbird.Filters/Xliff/Xliff2/Xliff2Serializer.cs
@@ -1021,26 +1021,12 @@ public static class Xliff2Serializer
 
     public static bool IsXliff2(string content)
     {
-        try
+        if (TryGetXliffVersion(content, out var version))
         {
-            var xliffNode = GetRootNode(content);
-            if (xliffNode == null)
-            {
-                return false;
-            }
-
-            var version = xliffNode.Get("version");
-            if (string.IsNullOrEmpty(version))
-            {
-                return false;
-            }
-
             return version.StartsWith("2.");
         }
-        catch (Exception)
-        {
-            return false;
-        }
+
+        return false;
     }
 
     public static bool TryGetXliffVersion(string content, out string version)
@@ -1050,6 +1036,9 @@ public static class Xliff2Serializer
         {
             var xliffNode = GetRootNode(content);
             if (xliffNode == null)
+                return false;
+
+            if (xliffNode.Name.LocalName != "xliff")
                 return false;
 
             var v = xliffNode.Get("version");


### PR DESCRIPTION
Added a public method for a robust XLIFF version checking for TMSes.

Sample of how we have to do it now:
```csharp
var fileContent = System.Text.Encoding.UTF8.GetString(fileBytes);

var isXliffV21 = fileContent.Contains("version=\"2.1\"") && fileContent.Contains("xmlns=\"urn:oasis:names:tc:xliff:document:2.0\"");
var isXliffV22 = fileContent.Contains("xmlns=\"urn:oasis:names:tc:xliff:document:2.2\"");

if (isXliffV21 || isXliffV22)
{
    // convert file to v2.0
}
```

What it would look like with a public method:
```csharp
var fileContent = System.Text.Encoding.UTF8.GetString(fileBytes);

if (Xliff2Serializer.TryGetXliffVersion(fileContent, out var version)
    && version != "2.0")
{
    // convert file to v2.0
}
```

## ⚠️ Changes in `isXliff1` and `isXliff2` checks

Both v1 and v2 serializers have this method that they both will work on any xliff file. But there is a change in checks:

* XLIFF v1 serializer now checks only that the root node is `xliff` (dropped namespace check)
* XLIFF v2 serializer now checks the root node is `xliff` (added root node name validation)