### PR TITLE
Add Localization Quality Rating data category from ITS module

### DIFF
--- a/Blackbird.Filters.Tests/Xliff2/XLIFF valid/withLocQualityRating.xlf
+++ b/Blackbird.Filters.Tests/Xliff2/XLIFF valid/withLocQualityRating.xlf
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.2" xmlns:its="http://www.w3.org/2005/11/its" version="2.2" srcLang="en" trgLang="fr">
+	<file id="f1"
+			its:locQualityRatingScore="98.0" its:locQualityRatingScoreThreshold="99"
+			its:locQualityRatingVote="16" its:locQualityRatingVoteThreshold="10"
+			its:locQualityRatingProfileRef="http://example.org/qaModel/v13">
+		<notes>
+			<note id="n1">note for file.</note>
+		</notes>
+		<group id="g1"
+			its:locQualityRatingScore="90" its:locQualityRatingScoreThreshold="95.0"
+			its:locQualityRatingVote="12" its:locQualityRatingVoteThreshold="5"
+			its:locQualityRatingProfileRef="http://example.org/qaModel/v13">
+			<notes>
+				<note id="n1">note for group</note>
+			</notes>
+			<unit id="u1"
+				its:locQualityRatingScore="74.9" its:locQualityRatingScoreThreshold="75"
+				its:locQualityRatingVote="0" its:locQualityRatingVoteThreshold="5">				
+				<notes>
+					<note id="n1">note for unit</note>
+				</notes>
+				<segment id="s1">
+					<source>
+						<pc id="1">
+							Hello World!
+						</pc>
+					</source>
+					<target>
+						<pc id="1">
+							Bonjour le Monde!
+						</pc>
+					</target>
+				</segment>
+			</unit>
+		</group>
+		<unit id="u2"
+			  its:locQualityRatingScore="0.0" its:locQualityRatingScoreThreshold="75.0"
+			  its:locQualityRatingVote="999" its:locQualityRatingVoteThreshold="100"
+			  its:locQualityRatingProfileRef="http://example.org/qaModel/v13">
+			<notes>
+				<note id="n1">note for unit</note>
+			</notes>
+			<segment id="s1">
+				<source>
+					Hello World!
+				</source>
+				<target>
+					Bonjour le Monde!
+				</target>
+			</segment>
+		</unit>
+	</file>
+</xliff>

--- a/Blackbird.Filters.Tests/Xliff2/Xliff2ValidTestSuiteTests.cs
+++ b/Blackbird.Filters.Tests/Xliff2/Xliff2ValidTestSuiteTests.cs
@@ -28,6 +28,7 @@ public class Xliff2ValidTestSuiteTests : TestBase
     [TestCase("withCDataSections")]
     [TestCase("withCommentAnnotations")]
     [TestCase("withGlossary")]
+    [TestCase("withLocQualityRating")]
     [TestCase("withMatches")]
     [TestCase("withModulesAttributesInEc")]
     [TestCase("withNotes")]

--- a/Blackbird.Filters/Blackbird.Filters.csproj
+++ b/Blackbird.Filters/Blackbird.Filters.csproj
@@ -11,7 +11,7 @@
 	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	  <PackageTags>Blackbird</PackageTags>
 	  <Copyright>Copyright © 2021-2025 Blackbird.io</Copyright>
-	  <Version>1.1.20</Version>
+	  <Version>1.1.21</Version>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/Blackbird.Filters/Transformations/Group.cs
+++ b/Blackbird.Filters/Transformations/Group.cs
@@ -1,8 +1,11 @@
-﻿namespace Blackbird.Filters.Transformations;
+﻿using Blackbird.Filters.Transformations.Modules;
+
+namespace Blackbird.Filters.Transformations;
 
 public class Group : UnitGrouping
 {
     public List<UnitGrouping> Children { get; set; } = [];
+    public ItsLocQuality? ItsLocQuality { get; set; }
 
     public IEnumerable<Unit> GetUnits()
     {

--- a/Blackbird.Filters/Transformations/Modules/ItsLocQuality.cs
+++ b/Blackbird.Filters/Transformations/Modules/ItsLocQuality.cs
@@ -1,0 +1,23 @@
+﻿using System.Xml.Linq;
+
+namespace Blackbird.Filters.Transformations.Modules;
+
+/// <summary>
+/// Expresses results of localization quality assessment in the form of aggregated ratings, either as scores or as voting results.
+/// </summary>
+/// <see cref="https://docs.oasis-open.org/xliff/xliff-core/v2.2/csd02/xliff-extended-v2.2-csd02-part2.html#Localization_Quality_Rating"/>
+/// <param name="LocQualityRatingScore">A decimal number between 0.0 and 100.0. The higher the number the better the quality rating.</param>
+/// <param name="LocQualityRatingScoreThreshold">A decimal number between 0.0 and 100.0. Scores under the given threshold indicate a quality check fail.</param>
+/// <param name="LocQualityRatingVote">An integer number. This attribute provides the quality rating voting (crowd assessment) of target text, the higher the number the more positive votes or the better margin of positive votes over negative votes.</param>
+/// <param name="LocQualityRatingVoteThreshold">An integer number. This attribute provides the minimum passing vote threshold. Votes under the given threshold indicate a quality check fail.</param>
+/// <param name="LocQualityRatingProfileRef">An Internationalized Resource Identifier (IRI). This attribute references a quality assessment model that has been used for the rating (either scoring or voting).</param>
+public sealed record class ItsLocQuality(
+    double? LocQualityRatingScore,
+    double? LocQualityRatingScoreThreshold,
+    int? LocQualityRatingVote,
+    int? LocQualityRatingVoteThreshold,
+    string? LocQualityRatingProfileRef
+)
+{
+    public static readonly XNamespace ItsXNamespace = "http://www.w3.org/2005/11/its";
+}

--- a/Blackbird.Filters/Transformations/Transformation.cs
+++ b/Blackbird.Filters/Transformations/Transformation.cs
@@ -2,6 +2,7 @@
 using Blackbird.Filters.Constants;
 using Blackbird.Filters.Content;
 using Blackbird.Filters.Extensions;
+using Blackbird.Filters.Transformations.Modules;
 using Blackbird.Filters.Xliff.Xliff1;
 using Blackbird.Filters.Xliff.Xliff2;
 using System.Net.Mime;
@@ -32,6 +33,7 @@ public class Transformation(string? sourceLanguage, string? targetLanguage) : No
     public string? ExternalReference { get; set; }
     public List<Node> Children { get; set; } = [];
     public List<XObject> XliffOther { get; set; } = [];
+    public ItsLocQuality? ItsLocQuality { get; set; }
 
     private string? _xliffFileName;
     /// <summary>

--- a/Blackbird.Filters/Transformations/Unit.cs
+++ b/Blackbird.Filters/Transformations/Unit.cs
@@ -1,6 +1,9 @@
-﻿namespace Blackbird.Filters.Transformations;
+﻿using Blackbird.Filters.Transformations.Modules;
+
+namespace Blackbird.Filters.Transformations;
 
 public class Unit : UnitGrouping
 {
     public List<Segment> Segments { get; set; } = [];
+    public ItsLocQuality? ItsLocQuality { get; set; }
 }


### PR DESCRIPTION
Adds `ItsLocQuality` to Transformation, Group and Unit structural elements without inheritance.

Supports XLIFF v2 serialization and deserialization.